### PR TITLE
Fix recursive StringBuilder algorythm

### DIFF
--- a/PrefixSuffixRadix/PrefixSuffixRadix/PrefixTree.cs
+++ b/PrefixSuffixRadix/PrefixSuffixRadix/PrefixTree.cs
@@ -46,7 +46,10 @@ class PrefixTree
             yield return builder.ToString();
 
         if (node.Children == null)
+        {
+            builder.Remove(builder.Length - 1, 1);
             yield break;
+        }
 
         foreach(var childNode in node.Children.Values)
         {


### PR DESCRIPTION
Если это не конец слова - но дочерних нод нет, значит нужно прервать формирование StringBuilder'a и "укоротить" его для продолжения "составления" следующего слова,